### PR TITLE
Refactored package placement in aut.ap.Cli

### DIFF
--- a/src/main/java/aut/ap/Cli/Commands.java
+++ b/src/main/java/aut/ap/Cli/Commands.java
@@ -1,4 +1,4 @@
-package Cli;
+package aut.ap.Cli;
 
 
 import aut.ap.model.User;

--- a/src/main/java/aut/ap/Cli/EmailViewType.java
+++ b/src/main/java/aut/ap/Cli/EmailViewType.java
@@ -1,4 +1,4 @@
-package Cli;
+package aut.ap.Cli;
 
 
 public enum EmailViewType {

--- a/src/main/java/aut/ap/Cli/UserCommands.java
+++ b/src/main/java/aut/ap/Cli/UserCommands.java
@@ -1,4 +1,4 @@
-package Cli;
+package aut.ap.Cli;
 
 
 public enum UserCommands{


### PR DESCRIPTION
The CLI component was located outside the aut.ap package, which caused runtime errors. It has now been moved into aut.ap to resolve the issue